### PR TITLE
Fix: fix rm_msgs depend error in catkin build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
         rqt_gui
         rqt_gui_cpp
         std_msgs
+        rm_msgs
         )
 
 ## System dependencies are found with CMake's conventions


### PR DESCRIPTION
修复catkin build时依赖没有头文件的报错。